### PR TITLE
Feature/#1 프로젝트 서비스 기본적인 CRUD 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.3'
+    id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -23,13 +23,38 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2025.0.0")
+}
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    //Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    //Eurka
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/sejong/projectservice/ProjectServiceApplication.java
+++ b/src/main/java/com/sejong/projectservice/ProjectServiceApplication.java
@@ -2,8 +2,12 @@ package com.sejong.projectservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+//@EnableFeignClients(basePackages = "com.sejong.projectservice.infrastructure.client")
+@EnableDiscoveryClient
 public class ProjectServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sejong/projectservice/application/config/RedisConfig.java
+++ b/src/main/java/com/sejong/projectservice/application/config/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.sejong.projectservice.application.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // ObjectMapper 생성 및 타입 정보 설정
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+        objectMapper.registerModule(new JavaTimeModule()); // LocalDateTime 처리
+
+        // 직렬화기 생성자에 ObjectMapper 주입
+        Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(objectMapper, Object.class);
+
+        // key/value serializer 설정
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/sejong/projectservice/application/config/SwaggerConfig.java
+++ b/src/main/java/com/sejong/projectservice/application/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.sejong.projectservice.application.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "/project-service"),
+                @Server(url = "/")
+        },
+        info = @Info(
+                title = "Newsletter API",
+                version = "v1",
+                description = "뉴스레터 API 문서입니다."
+        )
+)
+@Configuration
+public class SwaggerConfig {
+
+
+}

--- a/src/main/java/com/sejong/projectservice/application/project/controller/ProjectController.java
+++ b/src/main/java/com/sejong/projectservice/application/project/controller/ProjectController.java
@@ -1,0 +1,96 @@
+package com.sejong.projectservice.application.project.controller;
+
+import com.sejong.projectservice.application.project.dto.request.ProjectFormRequest;
+import com.sejong.projectservice.application.project.dto.response.ProjectAddResponse;
+import com.sejong.projectservice.application.project.dto.response.ProjectPageResponse;
+import com.sejong.projectservice.application.project.dto.response.ProjectSpecifyInfo;
+import com.sejong.projectservice.application.project.dto.response.ProjectUpdateResponse;
+import com.sejong.projectservice.application.project.service.ProjectService;
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/project")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @GetMapping("/health")
+    public String health() {
+        return "OK";
+    }
+
+    @PostMapping("/add")
+    public ResponseEntity<ProjectAddResponse> add(
+            @RequestBody ProjectFormRequest projectFormRequest,
+            @RequestHeader("X-User-ID") String userId) {
+
+        ProjectAddResponse response = projectService.register(projectFormRequest, userId);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<ProjectPageResponse> getAll(
+            @RequestParam(name = "size") int size,
+            @RequestParam(name = "page") int page
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        ProjectPageResponse response = projectService.getAllProjects(pageable);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+    @PutMapping("/{projectId}")
+    public ResponseEntity<ProjectUpdateResponse> updateProject(
+            @PathVariable(name = "projectId") Long projectId,
+            @RequestBody ProjectFormRequest projectFormRequest
+    ) {
+        ProjectUpdateResponse response = projectService.update(projectId, projectFormRequest);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(response);
+    }
+
+    @GetMapping("{projectId}")
+    public ResponseEntity<ProjectSpecifyInfo> specifyProject(
+            @PathVariable(name = "projectId") Long projectId
+    ) {
+        ProjectSpecifyInfo response = projectService.findOne(projectId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+
+    @GetMapping("/search")
+    public ResponseEntity<ProjectPageResponse> searchProjects(
+            @RequestParam(name = "keyword", required = false) String keyword,
+            @RequestParam(name = "category", required = false) Category category,
+            @RequestParam(name = "status", required = false) ProjectStatus status,
+            @RequestParam(name = "sort", defaultValue = "createdAt") String sort,
+            @RequestParam(name = "direction", defaultValue = "desc") String direction,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.fromString(direction), sort)
+        );
+
+        ProjectPageResponse response = projectService.search(keyword, category, status, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+
+}

--- a/src/main/java/com/sejong/projectservice/application/project/dto/request/ProjectFormRequest.java
+++ b/src/main/java/com/sejong/projectservice/application/project/dto/request/ProjectFormRequest.java
@@ -1,0 +1,29 @@
+package com.sejong.projectservice.application.project.dto.request;
+
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProjectFormRequest {
+    private String title;
+    private LocalDateTime createdAt;
+    private String description;
+
+    private Category category;
+    private ProjectStatus projectStatus;
+    private List<String> collaborators;
+    private List<String> techStacks;
+    private List<String> subGoals;
+
+    private String thumbnail;
+    private String contentJson;
+
+}

--- a/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectAddResponse.java
+++ b/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectAddResponse.java
@@ -1,0 +1,22 @@
+package com.sejong.projectservice.application.project.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProjectAddResponse {
+    private String title;
+    private String message;
+
+    public static ProjectAddResponse from(String title, String message){
+        return ProjectAddResponse.builder()
+                .title(title)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectPageResponse.java
+++ b/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectPageResponse.java
@@ -1,0 +1,35 @@
+package com.sejong.projectservice.application.project.dto.response;
+
+import com.sejong.projectservice.core.project.domain.Project;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProjectPageResponse {
+    List<ProjectSimpleInfo> projects;
+    int size;
+    int element;
+    Long totalElements;
+
+    public static ProjectPageResponse from(Page<Project> projectPage) {
+
+        List<ProjectSimpleInfo> projectSimpleInfos = projectPage.stream()
+                .map(ProjectSimpleInfo::from)
+                .toList();
+
+        return ProjectPageResponse.builder()
+                .projects(projectSimpleInfos)
+                .size(projectPage.getSize())
+                .element(projectPage.getNumber())
+                .totalElements(projectPage.getTotalElements())
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectSimpleInfo.java
+++ b/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectSimpleInfo.java
@@ -1,0 +1,55 @@
+package com.sejong.projectservice.application.project.dto.response;
+
+import com.sejong.projectservice.core.collaborator.Collaborator;
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import com.sejong.projectservice.core.project.domain.Project;
+import com.sejong.projectservice.core.subgoal.SubGoal;
+import com.sejong.projectservice.core.techstack.TechStack;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProjectSimpleInfo {
+    private Long id;
+    private String title;
+    private String description;
+    private Category category;
+    private ProjectStatus projectStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String thumbnailUrl;
+    private List<TechStack> techStacks = new ArrayList<>();
+    private List<Collaborator> collaborators = new ArrayList<>();
+    private Integer collaboratorSize;
+
+    public static ProjectSimpleInfo from(Project project) {
+
+        List<Collaborator> collaboratorList = project.getCollaborators();
+
+        return ProjectSimpleInfo.builder()
+                .id(project.getId())
+                .title(project.getTitle())
+                .description(project.getDescription())
+                .category(project.getCategory())
+                .projectStatus(project.getProjectStatus())
+                .createdAt(project.getCreatedAt())
+                .updatedAt(project.getUpdatedAt())
+                .thumbnailUrl(project.getThumbnailUrl())
+                .techStacks(project.getTechStacks())
+                .collaborators(collaboratorList)
+                .collaboratorSize(collaboratorList.size())
+                .build();
+    }
+}
+
+// 상세 내용 및 하위목표가 없는 객체입니다.

--- a/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectSpecifyInfo.java
+++ b/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectSpecifyInfo.java
@@ -1,0 +1,52 @@
+package com.sejong.projectservice.application.project.dto.response;
+
+import com.sejong.projectservice.core.collaborator.Collaborator;
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import com.sejong.projectservice.core.project.domain.Project;
+import com.sejong.projectservice.core.subgoal.SubGoal;
+import com.sejong.projectservice.core.techstack.TechStack;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ProjectSpecifyInfo {
+    private Long id;
+    private String title;
+    private String description;
+    private Category category;
+    private ProjectStatus projectStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String thumbnailUrl;
+    private String contentJson;
+    private List<SubGoal> subGoals;
+    private List<TechStack> techStacks = new ArrayList<>();
+    private List<Collaborator> collaborators = new ArrayList<>();
+
+    public static ProjectSpecifyInfo from(Project project) {
+        return ProjectSpecifyInfo.builder()
+                .id(project.getId())
+                .title(project.getTitle())
+                .description(project.getDescription())
+                .category(project.getCategory())
+                .projectStatus(project.getProjectStatus())
+                .createdAt(project.getCreatedAt())
+                .updatedAt(project.getUpdatedAt())
+                .thumbnailUrl(project.getThumbnailUrl())
+                .contentJson(project.getContentJson())
+                .subGoals(project.getSubGoals())
+                .techStacks(project.getTechStacks())
+                .collaborators(project.getCollaborators())
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectUpdateResponse.java
+++ b/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectUpdateResponse.java
@@ -1,0 +1,22 @@
+package com.sejong.projectservice.application.project.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProjectUpdateResponse {
+    private String title;
+    private String message;
+
+    public static ProjectUpdateResponse from(String title, String message){
+        return ProjectUpdateResponse.builder()
+                .title(title)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/application/project/service/ProjectService.java
+++ b/src/main/java/com/sejong/projectservice/application/project/service/ProjectService.java
@@ -1,0 +1,65 @@
+package com.sejong.projectservice.application.project.service;
+
+import com.sejong.projectservice.application.project.dto.request.ProjectFormRequest;
+import com.sejong.projectservice.application.project.dto.response.ProjectAddResponse;
+import com.sejong.projectservice.application.project.dto.response.ProjectPageResponse;
+import com.sejong.projectservice.application.project.dto.response.ProjectSpecifyInfo;
+import com.sejong.projectservice.application.project.dto.response.ProjectUpdateResponse;
+import com.sejong.projectservice.core.assembler.ProjectAssembler;
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import com.sejong.projectservice.core.project.domain.Project;
+import com.sejong.projectservice.core.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectService {
+    private final ProjectRepository projectRepository;
+//    private final UserClient userClient;
+
+    @Transactional
+    public ProjectAddResponse register(ProjectFormRequest projectFormRequest, String userId) {
+//        try {
+//            boolean exists = userClient.exists(userId);
+//            if (!exists) {
+//                userId = "1";
+//            }
+//        } catch (Exception e) {
+//
+//            System.err.println("user-service 호출 실패: " + e.getMessage());
+//            userId = "1";
+//        }
+        userId = "1";
+
+        Project project = ProjectAssembler.toDomain(projectFormRequest , Long.valueOf(userId));
+        Project savedProject = projectRepository.save(project);
+        return ProjectAddResponse.from(savedProject.getTitle(), "저장 완료");
+    }
+
+    public ProjectPageResponse getAllProjects(Pageable pageable) {
+
+        Page<Project> projectPage = projectRepository.findAll(pageable);
+        return ProjectPageResponse.from(projectPage);
+    }
+
+    public ProjectUpdateResponse update(Long projectId, ProjectFormRequest projectFormRequest) {
+        Project project = ProjectAssembler.toDomain(projectFormRequest, null);
+        Project updatedProject = projectRepository.update(project , projectId);
+        return ProjectUpdateResponse.from(updatedProject.getTitle(), "수정 완료");
+    }
+
+    public ProjectPageResponse search(String keyword, Category category, ProjectStatus status, Pageable pageable) {
+        Page<Project> projectPage = projectRepository.searchWithFilters(keyword, category, status, pageable);
+        return ProjectPageResponse.from(projectPage);
+    }
+
+    public ProjectSpecifyInfo findOne(Long projectId) {
+        Project project = projectRepository.findOne(projectId);
+        return ProjectSpecifyInfo.from(project);
+    }
+}

--- a/src/main/java/com/sejong/projectservice/core/assembler/ProjectAssembler.java
+++ b/src/main/java/com/sejong/projectservice/core/assembler/ProjectAssembler.java
@@ -1,0 +1,42 @@
+package com.sejong.projectservice.core.assembler;
+
+import com.sejong.projectservice.application.project.dto.request.ProjectFormRequest;
+import com.sejong.projectservice.core.collaborator.Collaborator;
+import com.sejong.projectservice.core.project.domain.Project;
+import com.sejong.projectservice.core.subgoal.SubGoal;
+import com.sejong.projectservice.core.techstack.TechStack;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ProjectAssembler {
+
+    public static Project toDomain(ProjectFormRequest request, Long userId) {
+        List<Collaborator> collaborators = request.getCollaborators().stream()
+                .map(Collaborator::from)
+                .toList();
+
+        List<TechStack> techStacks = request.getTechStacks().stream()
+                .map(TechStack::of)
+                .toList();
+
+        List<SubGoal> subGoals = request.getSubGoals().stream()
+                .map(it -> SubGoal.from(it, false, LocalDateTime.now(), LocalDateTime.now()))
+                .toList();
+
+        return Project.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .category(request.getCategory())
+                .projectStatus(request.getProjectStatus())
+                .createdAt(request.getCreatedAt())
+                .updatedAt(LocalDateTime.now())
+                .thumbnailUrl(request.getThumbnail())
+                .contentJson(request.getContentJson())
+                .userId(userId)
+                .techStacks(techStacks)
+                .collaborators(collaborators)
+                .subGoals(subGoals)
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/core/collaborator/Collaborator.java
+++ b/src/main/java/com/sejong/projectservice/core/collaborator/Collaborator.java
@@ -1,0 +1,23 @@
+package com.sejong.projectservice.core.collaborator;
+
+import com.sejong.projectservice.infrastructure.project.entity.ProjectEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Collaborator {
+    private Long id;
+    private String collaboratorName;
+
+    public static Collaborator from(String collaboratorName) {
+        return Collaborator.builder()
+                .id(null)
+                .collaboratorName(collaboratorName)
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/core/enums/Category.java
+++ b/src/main/java/com/sejong/projectservice/core/enums/Category.java
@@ -1,0 +1,11 @@
+package com.sejong.projectservice.core.enums;
+
+public enum Category {
+    SYSTEM_HACKING,
+    WEB_HACKING,
+    DIGITAL_FORENSICS,
+    REVERSING,
+    CRYPTOGRAPHY,
+    NETWORK_SECURITY,
+    IOT_SECURITY
+}

--- a/src/main/java/com/sejong/projectservice/core/enums/ProjectStatus.java
+++ b/src/main/java/com/sejong/projectservice/core/enums/ProjectStatus.java
@@ -1,0 +1,7 @@
+package com.sejong.projectservice.core.enums;
+
+public enum ProjectStatus {
+    IN_PROGRESS,
+    COMPLETED,
+    ARCHIVED,
+}

--- a/src/main/java/com/sejong/projectservice/core/project/domain/Project.java
+++ b/src/main/java/com/sejong/projectservice/core/project/domain/Project.java
@@ -1,0 +1,37 @@
+package com.sejong.projectservice.core.project.domain;
+
+import com.sejong.projectservice.application.project.dto.request.ProjectFormRequest;
+import com.sejong.projectservice.core.collaborator.Collaborator;
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import com.sejong.projectservice.core.subgoal.SubGoal;
+import com.sejong.projectservice.core.techstack.TechStack;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Project {
+    private Long id;
+    private String title;
+    private String description;
+    private Category category;
+    private ProjectStatus projectStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String thumbnailUrl;
+    private String contentJson;
+    private Long userId;
+    private List<SubGoal> subGoals =new ArrayList<>();
+    private List<TechStack> techStacks = new ArrayList<>();
+    private List<Collaborator> collaborators = new ArrayList<>();
+
+}

--- a/src/main/java/com/sejong/projectservice/core/project/repository/ProjectRepository.java
+++ b/src/main/java/com/sejong/projectservice/core/project/repository/ProjectRepository.java
@@ -1,0 +1,22 @@
+package com.sejong.projectservice.core.project.repository;
+
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import com.sejong.projectservice.core.project.domain.Project;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectRepository {
+
+    Project save(Project project);
+
+    Page<Project> findAll(Pageable pageable);
+
+    Project update(Project project, Long projectId);
+
+    Page<Project> searchWithFilters(String keyword, Category category, ProjectStatus status, Pageable pageable);
+
+    Project findOne(Long projectId);
+}

--- a/src/main/java/com/sejong/projectservice/core/subgoal/SubGoal.java
+++ b/src/main/java/com/sejong/projectservice/core/subgoal/SubGoal.java
@@ -1,0 +1,31 @@
+package com.sejong.projectservice.core.subgoal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SubGoal {
+
+    private Long id;
+    private String content;
+    private Boolean completed;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static SubGoal from(String content, Boolean completed,LocalDateTime createdAt, LocalDateTime updatedAt) {
+        return SubGoal.builder()
+                .id(null)
+                .content(content)
+                .completed(completed)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/core/techstack/TechStack.java
+++ b/src/main/java/com/sejong/projectservice/core/techstack/TechStack.java
@@ -1,0 +1,42 @@
+package com.sejong.projectservice.core.techstack;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TechStack {
+
+    private Long id;
+    private String name;
+
+    public static TechStack of(String name) {
+        return TechStack.builder()
+                .id(null)
+                .name(name)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TechStack that = (TechStack) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/sejong/projectservice/core/techstack/TechStackRepository.java
+++ b/src/main/java/com/sejong/projectservice/core/techstack/TechStackRepository.java
@@ -1,0 +1,8 @@
+package com.sejong.projectservice.core.techstack;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TechStackRepository {
+    TechStack  findOrCreateByName(String name);
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/assembler/ProjectEntityAssembler.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/assembler/ProjectEntityAssembler.java
@@ -1,0 +1,37 @@
+package com.sejong.projectservice.infrastructure.assembler;
+
+import com.sejong.projectservice.core.project.domain.Project;
+import com.sejong.projectservice.infrastructure.collborator.entity.CollaboratorEntity;
+import com.sejong.projectservice.infrastructure.project.entity.ProjectEntity;
+import com.sejong.projectservice.infrastructure.projecttechstack.entity.ProjectTechStackEntity;
+import com.sejong.projectservice.infrastructure.subgoal.SubGoalEntity;
+import com.sejong.projectservice.infrastructure.techstack.entity.TechStackEntity;
+import com.sejong.projectservice.infrastructure.techstack.repository.TechStackJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectEntityAssembler {
+
+    private final TechStackJpaRepository techStackJpaRepository;
+
+    public void assemble(ProjectEntity projectEntity, Project project) {
+
+        project.getCollaborators().forEach(
+                c -> CollaboratorEntity.from(c, projectEntity)
+        );
+
+        project.getSubGoals().forEach(
+                s -> SubGoalEntity.from(s, projectEntity)
+        );
+
+        project.getTechStacks().stream()
+                .map(t -> techStackJpaRepository.findByName(t.getName())
+                        .orElseGet(() -> techStackJpaRepository.save(new TechStackEntity(null, t.getName()))))
+                .forEach(t -> ProjectTechStackEntity.from(projectEntity, t));
+
+    }
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/client/UserClient.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/client/UserClient.java
@@ -1,0 +1,14 @@
+package com.sejong.projectservice.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+//@FeignClient(name = "user-service")
+//public interface UserClient {
+//    @GetMapping("/users/{id}")
+//    String getUserById(@PathVariable("id") String id);
+//
+//    @GetMapping("/users/{userId}/exists")
+//    boolean exists(@PathVariable("userId") String userId);
+//}

--- a/src/main/java/com/sejong/projectservice/infrastructure/collborator/entity/CollaboratorEntity.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/collborator/entity/CollaboratorEntity.java
@@ -1,0 +1,58 @@
+package com.sejong.projectservice.infrastructure.collborator.entity;
+
+import com.sejong.projectservice.core.collaborator.Collaborator;
+import com.sejong.projectservice.infrastructure.project.entity.ProjectEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="collaborator")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CollaboratorEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="project_id", nullable=false)
+    private ProjectEntity projectEntity;
+
+    private String collaboratorName;
+
+    public static CollaboratorEntity from(Collaborator collaborator , ProjectEntity projectEntity) {
+
+        CollaboratorEntity entity = CollaboratorEntity.builder()
+                .collaboratorName(collaborator.getCollaboratorName())
+                .projectEntity(projectEntity)
+                .build();
+
+        entity.assignProjectEntity(projectEntity);
+        return entity;
+    }
+
+    public Collaborator toDomain() {
+        return Collaborator.builder()
+                .id(this.getId())
+                .collaboratorName(this.getCollaboratorName())
+                .build();
+    }
+
+    public void assignProjectEntity(ProjectEntity projectEntity) {
+        this.projectEntity = projectEntity;
+        projectEntity.getCollaborators().add(this);
+    }
+
+    public static CollaboratorEntity withoutProject(Collaborator collaborator) {
+        return CollaboratorEntity.builder()
+                .id(collaborator.getId())
+                .collaboratorName(collaborator.getCollaboratorName())
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/project/entity/ProjectEntity.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/project/entity/ProjectEntity.java
@@ -1,0 +1,131 @@
+package com.sejong.projectservice.infrastructure.project.entity;
+
+import com.sejong.projectservice.core.collaborator.Collaborator;
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import com.sejong.projectservice.core.project.domain.Project;
+import com.sejong.projectservice.core.subgoal.SubGoal;
+import com.sejong.projectservice.core.techstack.TechStack;
+import com.sejong.projectservice.infrastructure.collborator.entity.CollaboratorEntity;
+import com.sejong.projectservice.infrastructure.projecttechstack.entity.ProjectTechStackEntity;
+import com.sejong.projectservice.infrastructure.subgoal.SubGoalEntity;
+import com.sejong.projectservice.infrastructure.techstack.entity.TechStackEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "project")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class ProjectEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(50)")
+    private Category category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(50)")
+    private ProjectStatus projectStatus;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    private String thumbnailUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String contentJson;
+
+    @OneToMany(mappedBy = "projectEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectTechStackEntity> projectTechStacks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "projectEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CollaboratorEntity> collaborators = new ArrayList<>();
+
+    @OneToMany(mappedBy = "projectEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SubGoalEntity> subGoals = new ArrayList<>();
+
+    // createdAt만 제외했습니다.
+    public void updateBasicInfo(Project project){
+        clearAllRelations();
+        this.title = project.getTitle();
+        this.description = project.getDescription();
+        this.category = project.getCategory();
+        this.projectStatus = project.getProjectStatus();
+        this.updatedAt = project.getUpdatedAt();
+        this.thumbnailUrl = project.getThumbnailUrl();
+        this.contentJson = project.getContentJson();
+    }
+
+    public void clearAllRelations() {
+        this.projectTechStacks.clear();
+        this.collaborators.clear();
+        this.subGoals.clear();
+    }
+
+    public static ProjectEntity from(Project project) {
+        return ProjectEntity.builder()
+                .title(project.getTitle())
+                .description(project.getDescription())
+                .category(project.getCategory())
+                .projectStatus(project.getProjectStatus())
+                .thumbnailUrl(project.getThumbnailUrl())
+                .contentJson(project.getContentJson())
+                .createdAt(project.getCreatedAt())
+                .updatedAt(project.getUpdatedAt())
+                .projectTechStacks(new ArrayList<>())
+                .collaborators(new ArrayList<>())
+                .subGoals(new ArrayList<>())
+                .userId(project.getUserId())
+                .build();
+    }
+
+    public Project toDomain() {
+
+        List<Collaborator> collaboratorList = collaborators.stream()
+                .map(CollaboratorEntity::toDomain)
+                .toList();
+        List<TechStack> uniqueTechStackList = projectTechStacks.stream()
+                .map(ProjectTechStackEntity::getTechStackEntity)
+                .map(TechStackEntity::toDomain)
+                .distinct()
+                .toList();
+
+        List<SubGoal> subGoalList = subGoals.stream()
+                .map(SubGoalEntity::toDomain)
+                .toList();
+
+        return Project.builder()
+                .id(this.id)
+                .title(this.title)
+                .description(this.description)
+                .category(this.category)
+                .projectStatus(this.projectStatus)
+                .thumbnailUrl(this.thumbnailUrl)
+                .contentJson(this.contentJson)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
+                .collaborators(collaboratorList)
+                .techStacks(uniqueTechStackList)
+                .subGoals(subGoalList)
+                .userId(this.userId)
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/project/repository/ProjectJpaRepository.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/project/repository/ProjectJpaRepository.java
@@ -1,0 +1,22 @@
+package com.sejong.projectservice.infrastructure.project.repository;
+
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import com.sejong.projectservice.infrastructure.project.entity.ProjectEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ProjectJpaRepository extends JpaRepository<ProjectEntity, Long> {
+
+    @Query("SELECT p FROM ProjectEntity p "+
+    "WHERE (:keyword IS NULL OR p.title LIKE %:keyword% OR p.description LIKE %:keyword%) "+
+            "AND (:category IS NULL OR p.category = :category) "+
+            "AND (:status IS NULL OR p.projectStatus = :status)")
+    Page<ProjectEntity> searchWithFilters(@Param("keyword")String keyword,
+                                          @Param("category")Category category,
+                                          @Param("status")ProjectStatus status,
+                                          Pageable pageable);
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/project/repository/ProjectRepositoryImpl.java
@@ -1,0 +1,91 @@
+package com.sejong.projectservice.infrastructure.project.repository;
+
+import com.sejong.projectservice.core.assembler.ProjectAssembler;
+import com.sejong.projectservice.core.enums.Category;
+import com.sejong.projectservice.core.enums.ProjectStatus;
+import com.sejong.projectservice.core.project.domain.Project;
+import com.sejong.projectservice.core.project.repository.ProjectRepository;
+import com.sejong.projectservice.infrastructure.assembler.ProjectEntityAssembler;
+import com.sejong.projectservice.infrastructure.collborator.entity.CollaboratorEntity;
+import com.sejong.projectservice.infrastructure.project.entity.ProjectEntity;
+import com.sejong.projectservice.infrastructure.projecttechstack.entity.ProjectTechStackEntity;
+import com.sejong.projectservice.infrastructure.subgoal.SubGoalEntity;
+import com.sejong.projectservice.infrastructure.techstack.entity.TechStackEntity;
+import com.sejong.projectservice.infrastructure.techstack.repository.TechStackJpaRepository;
+import com.sejong.projectservice.infrastructure.techstack.repository.TechStackRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectRepositoryImpl implements ProjectRepository {
+
+    private final ProjectJpaRepository projectJpaRepository;
+    private final ProjectEntityAssembler projectAssembler;
+
+    @Override
+    public Project save(Project project) {
+
+        ProjectEntity projectEntity = ProjectEntity.from(project);
+        projectAssembler.assemble(projectEntity, project);
+        ProjectEntity entity = projectJpaRepository.save(projectEntity);
+        return entity.toDomain();
+    }
+
+    @Override
+    public Page<Project> findAll(Pageable pageable) {
+        Page<ProjectEntity> pageProjectEntities = projectJpaRepository.findAll(pageable);
+        List<Project> projects = pageProjectEntities
+                .stream()
+                .map(ProjectEntity::toDomain)
+                .toList();
+
+        return new PageImpl<>(
+                projects,
+                pageable,
+                pageProjectEntities.getTotalElements()
+        );
+    }
+
+    @Override
+    @Transactional
+    public Project update(Project project, Long projectId) {
+        ProjectEntity projectEntity = projectJpaRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("Project not found"));
+
+        projectEntity.updateBasicInfo(project);
+        projectEntity.clearAllRelations();
+        projectAssembler.assemble(projectEntity, project);
+
+        ProjectEntity responseEntity = projectJpaRepository.save(projectEntity);
+        return responseEntity.toDomain();
+    }
+
+    @Override
+    public Page<Project> searchWithFilters(String keyword, Category category, ProjectStatus status, Pageable pageable) {
+        Page<ProjectEntity> pageProjectEntities = projectJpaRepository.searchWithFilters(keyword, category, status, pageable);
+        List<Project> projects = pageProjectEntities.stream()
+                .map(ProjectEntity::toDomain)
+                .toList();
+        return new PageImpl<>(
+                projects,
+                pageable,
+                pageProjectEntities.getTotalElements()
+        );
+    }
+
+    @Override
+    public Project findOne(Long projectId) {
+        ProjectEntity projectEntity = projectJpaRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("Project not found"));
+        return projectEntity.toDomain();
+    }
+
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/projecttechstack/entity/ProjectTechStackEntity.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/projecttechstack/entity/ProjectTechStackEntity.java
@@ -1,0 +1,45 @@
+package com.sejong.projectservice.infrastructure.projecttechstack.entity;
+
+import com.sejong.projectservice.infrastructure.project.entity.ProjectEntity;
+import com.sejong.projectservice.infrastructure.techstack.entity.TechStackEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="project_techstack")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class ProjectTechStackEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="project_id", nullable=false)
+    private ProjectEntity projectEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="techstack_id",nullable=false)
+    private TechStackEntity techStackEntity;
+
+    public void assignProjectEntity(ProjectEntity projectEntity) {
+        this.projectEntity = projectEntity;
+        projectEntity.getProjectTechStacks().add(this);
+    }
+
+    public static ProjectTechStackEntity from(ProjectEntity projectEntity, TechStackEntity techStackEntity) {
+        ProjectTechStackEntity projectTechStackEntity = ProjectTechStackEntity.builder()
+                .projectEntity(projectEntity)
+                .techStackEntity(techStackEntity)
+                .build();
+
+        projectTechStackEntity.assignProjectEntity(projectEntity);
+        return projectTechStackEntity;
+    }
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/redis/TechStackCacheRefresher.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/redis/TechStackCacheRefresher.java
@@ -1,0 +1,23 @@
+package com.sejong.projectservice.infrastructure.redis;
+
+import com.sejong.projectservice.core.techstack.TechStack;
+import com.sejong.projectservice.core.techstack.TechStackRepository;
+import com.sejong.projectservice.infrastructure.techstack.entity.TechStackEntity;
+import com.sejong.projectservice.infrastructure.techstack.repository.TechStackJpaRepository;
+import com.sejong.projectservice.infrastructure.techstack.repository.TechStackRepositoryImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TechStackCacheRefresher {
+
+
+
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/redis/TechStackRedisService.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/redis/TechStackRedisService.java
@@ -1,0 +1,34 @@
+package com.sejong.projectservice.infrastructure.redis;
+
+import com.sejong.projectservice.core.techstack.TechStack;
+import com.sejong.projectservice.infrastructure.techstack.entity.TechStackEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TechStackRedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private String key(String techStackName) {
+        return "techstack:" + techStackName;
+    }
+
+    public Optional<Long> getTechStackId(String techStackName) {
+        String value = redisTemplate.opsForValue().get(key(techStackName));
+        if (value == null) return Optional.empty();
+        return Optional.of(Long.valueOf(value));
+    }
+
+    public void cacheTechStack(String techStackName, TechStack techStack) {
+        redisTemplate.opsForValue().set(key(techStackName), String.valueOf(techStack));
+    }
+
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/subgoal/SubGoalEntity.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/subgoal/SubGoalEntity.java
@@ -1,0 +1,63 @@
+package com.sejong.projectservice.infrastructure.subgoal;
+
+import com.sejong.projectservice.core.subgoal.SubGoal;
+import com.sejong.projectservice.infrastructure.project.entity.ProjectEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "subgoal")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class SubGoalEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    private Boolean completed;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private ProjectEntity projectEntity;
+
+    public static SubGoalEntity from(SubGoal subGoal , ProjectEntity projectEntity) {
+        SubGoalEntity subGoalEntity = SubGoalEntity.builder()
+                .id(null)
+                .content(subGoal.getContent())
+                .completed(subGoal.getCompleted())
+                .createdAt(subGoal.getCreatedAt())
+                .updatedAt(subGoal.getUpdatedAt())
+                .build();
+
+        subGoalEntity.assignProjectEntity(projectEntity);
+        return subGoalEntity;
+    }
+
+    public SubGoal toDomain() {
+        return SubGoal.builder()
+                .id(id)
+                .content(content)
+                .completed(completed)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
+
+    public void assignProjectEntity(ProjectEntity projectEntity) {
+        this.projectEntity = projectEntity;
+        projectEntity.getSubGoals().add(this);
+    }
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/techstack/entity/TechStackEntity.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/techstack/entity/TechStackEntity.java
@@ -1,0 +1,37 @@
+package com.sejong.projectservice.infrastructure.techstack.entity;
+
+import com.sejong.projectservice.core.techstack.TechStack;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "techstack")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TechStackEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    public static TechStackEntity from(TechStack techStack) {
+        return TechStackEntity.builder()
+                .id(null)
+                .name(techStack.getName())
+                .build();
+    }
+
+    public TechStack toDomain() {
+        return TechStack.builder()
+                .id(this.getId())
+                .name(this.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/techstack/repository/TechStackJpaRepository.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/techstack/repository/TechStackJpaRepository.java
@@ -1,0 +1,11 @@
+package com.sejong.projectservice.infrastructure.techstack.repository;
+
+import com.sejong.projectservice.core.techstack.TechStackRepository;
+import com.sejong.projectservice.infrastructure.techstack.entity.TechStackEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TechStackJpaRepository extends JpaRepository<TechStackEntity,Long> {
+    Optional<TechStackEntity> findByName(String name);
+}

--- a/src/main/java/com/sejong/projectservice/infrastructure/techstack/repository/TechStackRepositoryImpl.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/techstack/repository/TechStackRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.sejong.projectservice.infrastructure.techstack.repository;
+
+import com.sejong.projectservice.core.techstack.TechStack;
+import com.sejong.projectservice.core.techstack.TechStackRepository;
+import com.sejong.projectservice.infrastructure.techstack.entity.TechStackEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TechStackRepositoryImpl implements TechStackRepository {
+    private final TechStackJpaRepository techStackJpaRepository;
+
+    @Override
+    public TechStack findOrCreateByName(String name) {
+        return techStackJpaRepository.findByName(name)
+                .map(TechStackEntity::toDomain)
+                .orElseGet(() -> {
+                    TechStackEntity saved = techStackJpaRepository.save(new TechStackEntity(null, name));
+                    return saved.toDomain();
+                });
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,37 @@
+server:
+  port: 8080
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/tborntb?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: root
+
+  sql:
+    init:
+      mode: always #never 필요없으면 해당 never넣으면 됩니다~
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
+    show-sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          batch_size: 50
+          default_batch_fetch_size: 100
+        order_inserts: true
+        order_updates: true
+
+  thymeleaf:
+    enabled: false
+
+logging:
+  level:
+    org.springframework.scheduling.annotation.AsyncAnnotationBeanPostProcessor: DEBUG
+    com.sejong.newsletterservice.infrastructure.email: DEBUG
+
+

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,49 @@
+server:
+  port: 0
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/tborntb?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: root
+
+  sql:
+    init:
+      mode: always
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
+    show-sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          batch_size: 50
+          default_batch_fetch_size: 100
+        order_inserts: true
+        order_updates: true
+
+  thymeleaf:
+    enabled: false
+
+  cloud:
+    discovery:
+      enabled: true
+    loadbalancer:
+      ribbon:
+        enabled: false
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+    register-with-eureka: true
+    fetch-registry: true
+
+logging:
+  level:
+    org.springframework.scheduling.annotation.AsyncAnnotationBeanPostProcessor: DEBUG
+    com.sejong.newsletterservice.infrastructure.email: DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=project-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  application:
+    name: project-service
+
+  profiles:
+    active: prod # local ?? prod? ??? ?? ???~
+
+springdoc:
+  api-docs:
+    version: openapi_3_0
+    enabled: true
+    path: /v3/api-docs
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html


### PR DESCRIPTION
## #️⃣ 이슈

- close #1

---

## 🔎 작업 내용

- 프로젝트 도메인 구조 전면 리팩토링  
- API 요청/응답 DTO 분리 및 정비  
- 도메인, 엔티티, 레포지토리 인터페이스 명확히 분리  
- Swagger 설정 적용  
- Redis 설정 적용  
- `application.yml` 및 환경별 설정 파일 정비  
- Gradle 종속성 및 메인 클래스 수정  

---

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

- Yorkie 연동을 고려한 구조 확장 가능성  
- DTO와 도메인 간 매핑 로직의 위치 적절성 (Assembler vs Mapper)  
- 프로젝트 수정 시 연관관계 비교 및 처리 전략 개선 여부  

---

## 🧲 참고 자료 및 공유 사항
