### PR TITLE
Feign username관련 권한 검증 로직 구현

### DIFF
--- a/src/main/java/com/sejong/projectservice/application/category/controller/CategoryController.java
+++ b/src/main/java/com/sejong/projectservice/application/category/controller/CategoryController.java
@@ -21,10 +21,10 @@ public class CategoryController {
     @PostMapping("")
     @Operation(summary = "카테고리 저장")
     public ResponseEntity<CategoryResponse> addCategory(
-            @RequestHeader("x-user") String userId,
+            @RequestHeader("X-User-Role") String userRole,
             @RequestBody @Valid CategoryAddRequest categoryAddRequest
     ) {
-        CategoryResponse response = categoryService.create(userId, categoryAddRequest.getName());
+        CategoryResponse response = categoryService.create(userRole, categoryAddRequest.getName());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/src/main/java/com/sejong/projectservice/application/category/service/CategoryService.java
+++ b/src/main/java/com/sejong/projectservice/application/category/service/CategoryService.java
@@ -2,6 +2,8 @@ package com.sejong.projectservice.application.category.service;
 
 import com.sejong.projectservice.application.category.controller.dto.CategoryAllResponse;
 import com.sejong.projectservice.application.category.controller.dto.CategoryResponse;
+import com.sejong.projectservice.application.common.error.code.ErrorCode;
+import com.sejong.projectservice.application.common.error.exception.ApiException;
 import com.sejong.projectservice.core.category.Category;
 import com.sejong.projectservice.core.category.CategoryRepository;
 import com.sejong.projectservice.core.project.domain.Project;
@@ -21,22 +23,22 @@ public class CategoryService {
     private final ProjectRepository projectRepository;
 
     @Transactional
-    public CategoryResponse create(String userId, String name) {
-        //todo 이거 관리자 전용 api라서 관리자가 맞는지 검증해야 됩니다.
+    public CategoryResponse create(String userRole, String name) {
+        validateAdminRole(userRole);
         Category category = categoryRepository.save(name);
         return CategoryResponse.from(category);
-
     }
 
     @Transactional
-    public CategoryResponse update(String userId, String prevName, String nextName) {
-        //todo 이거 관리자 전용 api라서 관리자가 맞는지 검증해야 됩니다.
+    public CategoryResponse update(String userRole, String prevName, String nextName) {
+        validateAdminRole(userRole);
         Category category = categoryRepository.update(prevName, nextName);
         return CategoryResponse.updateFrom(category);
     }
 
-    public CategoryResponse remove(String userId, String name) {
-        //todo 이거 관리자 전용 api라서 관리자가 맞는지 검증해야 됩니다.
+    @Transactional
+    public CategoryResponse remove(String userRole, String name) {
+        validateAdminRole(userRole);
         Category category = categoryRepository.delete(name);
         return CategoryResponse.deleteFrom(category);
     }
@@ -49,14 +51,17 @@ public class CategoryService {
 
     @Transactional
     public CategoryAllResponse updateProject( String userName,Long projectId, List<String> categoryNames) {
-        //todo 만약 프로젝트 만든 owner가 특정 유저들에게 수정권한을 부여하는 비지니스가 생긴다면
-        //todo 이 코드는 손봐야 된다. 현재 유저를 찾고 그 유저가 권한이 있는지 검증해야된다.
-        //todo 또한 그런 비지니스 로직이 생긴다면 전체 collaboator의 연관관계를 끊지 말고 하나하나 추가 아니면 기존게 있다면 보존 형태로 해야되겠다.
         Project project = projectRepository.findOne(projectId);
-//        project.ensureCollaboratorExists(userName);
+        project.validateUserPermission(userName);
         project.updateCategory(categoryNames);
 
         Project updatedProject = projectRepository.update(project);
         return CategoryAllResponse.from(updatedProject.getCategories());
+    }
+
+    private void validateAdminRole(String userRole) {
+        if(!userRole.equals("ADMIN")){
+            throw new ApiException(ErrorCode.BAD_REQUEST,"관리자만 가능합니다.");
+        }
     }
 }

--- a/src/main/java/com/sejong/projectservice/application/collaborator/controller/CollaboratorController.java
+++ b/src/main/java/com/sejong/projectservice/application/collaborator/controller/CollaboratorController.java
@@ -20,12 +20,12 @@ public class CollaboratorController {
     @PutMapping("/{projectId}")
     @Operation(summary = "협력자들 수정")
     public ResponseEntity<List<Collaborator>> updateCollaborator(
-            @RequestHeader("x-user") String userId,
+            @RequestHeader("X-User-Id") String username,
             @RequestBody List<String> collaboratorNames,
             @PathVariable(name = "projectId") Long projectId
 
     ) {
-        List<Collaborator> response = collaboratorService.updateProject(userId, projectId, collaboratorNames);
+        List<Collaborator> response = collaboratorService.updateProject(username, projectId, collaboratorNames);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/sejong/projectservice/application/collaborator/dto/response/CollaboratorResponse.java
+++ b/src/main/java/com/sejong/projectservice/application/collaborator/dto/response/CollaboratorResponse.java
@@ -1,0 +1,4 @@
+package com.sejong.projectservice.application.collaborator.dto.response;
+
+public class CollaboratorResponse {
+}

--- a/src/main/java/com/sejong/projectservice/application/collaborator/dto/response/CollaboratorResponse.java
+++ b/src/main/java/com/sejong/projectservice/application/collaborator/dto/response/CollaboratorResponse.java
@@ -1,4 +1,24 @@
 package com.sejong.projectservice.application.collaborator.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class CollaboratorResponse {
+    private Long id;
+    private String username;
+    private String nickname;
+
+    public static CollaboratorResponse of(Long id, String username, String nickname) {
+        return CollaboratorResponse.builder()
+                .id(id)
+                .username(username)
+                .nickname(nickname)
+                .build();
+    }
 }

--- a/src/main/java/com/sejong/projectservice/application/collaborator/service/CollaboratorService.java
+++ b/src/main/java/com/sejong/projectservice/application/collaborator/service/CollaboratorService.java
@@ -18,11 +18,11 @@ public class CollaboratorService {
     private final UserExternalService userExternalService;
 
     @Transactional
-    public List<Collaborator> updateProject(String userId, Long projectId, List<String> collaboratorNames) {
-//        userExternalService.validateExistence(collaboratorNames);
+    public List<Collaborator> updateProject(String username, Long projectId, List<String> collaboratorNames) {
+        userExternalService.validateExistence(username,collaboratorNames);
 
         Project project = projectRepository.findOne(projectId);
-        project.validateOwner(userId);
+        project.validateUserPermission(username);
         project.updateCollaborator(collaboratorNames);
         Project updatedProject = projectRepository.updateCollaborator(project);
         return updatedProject.getCollaborators();

--- a/src/main/java/com/sejong/projectservice/application/document/controller/DocumentController.java
+++ b/src/main/java/com/sejong/projectservice/application/document/controller/DocumentController.java
@@ -20,11 +20,11 @@ public class DocumentController {
     @PostMapping("/{projectId}")
     @Operation(summary = "다큐먼트 생성")
     public ResponseEntity<DocumentInfoRes> createDocumentInProject(
+            @RequestHeader("X-User-Id") String username,
             @PathVariable(name = "projectId") Long projectId,
             @RequestBody DocumentCreateReq request
     ) {
-        // Todo: member 권한 검증
-        DocumentInfoRes response = documentService.createDocument(projectId, request);
+        DocumentInfoRes response = documentService.createDocument(projectId, request, username);
         return ResponseEntity
                 .status(201)
                 .body(response);
@@ -42,21 +42,22 @@ public class DocumentController {
     @PutMapping("/{documentId}")
     @Operation(summary = "다큐먼트 수정")
     public ResponseEntity<DocumentInfoRes> updateDocument(
+            @RequestHeader("X-User-Id") String username,
             @PathVariable(name = "documentId") Long documentId,
             @RequestBody DocumentUpdateReq request
     ) {
-        // Todo: member 권한 검증
-        DocumentInfoRes documentInfoRes = documentService.updateDocument(documentId, request);
+        DocumentInfoRes documentInfoRes = documentService.updateDocument(documentId, request, username);
         return ResponseEntity.ok(documentInfoRes);
     }
 
     @DeleteMapping("/{documentId}")
     @Operation(summary = "다큐먼트 삭제")
     public ResponseEntity<Void> deleteDocument(
+            @RequestHeader("X-User-Id") String username,
             @PathVariable(name = "documentId") Long documentId
     ) {
-        // Todo: member 권한 검증
-        documentService.deleteDocument(documentId);
+
+        documentService.deleteDocument(documentId, username);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sejong/projectservice/application/document/service/DocumentService.java
+++ b/src/main/java/com/sejong/projectservice/application/document/service/DocumentService.java
@@ -9,6 +9,8 @@ import com.sejong.projectservice.core.document.repository.DocumentRepository;
 
 import java.util.UUID;
 
+import com.sejong.projectservice.core.project.domain.Project;
+import com.sejong.projectservice.core.project.repository.ProjectRepository;
 import com.sejong.projectservice.infrastructure.document.kafka.DocumentEventPublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,9 +22,12 @@ public class DocumentService {
 
     private final DocumentRepository documentRepository;
     private final DocumentEventPublisher documentEventPublisher;
+    private final ProjectRepository projectRepository;
 
     @Transactional
-    public DocumentInfoRes createDocument(Long projectId, DocumentCreateReq request) {
+    public DocumentInfoRes createDocument(Long projectId, DocumentCreateReq request, String username) {
+        Project project = projectRepository.findOne(projectId);
+        project.validateUserPermission(username);
         Document document = Assembler.toDocument(request, generateYorkieDocumentId(), projectId);
         Document savedDocument = documentRepository.save(document);
         documentEventPublisher.publishCreated(savedDocument);
@@ -36,14 +41,17 @@ public class DocumentService {
                 .substring(0, 7);
     }
 
+    @Transactional(readOnly = true)
     public DocumentInfoRes getDocument(Long documentId) {
         Document document = documentRepository.findById(documentId);
         return DocumentInfoRes.from(document);
     }
 
     @Transactional
-    public DocumentInfoRes updateDocument(Long documentId, DocumentUpdateReq request) {
+    public DocumentInfoRes updateDocument(Long documentId, DocumentUpdateReq request, String username) {
         Document document = documentRepository.findById(documentId);
+        Project project = projectRepository.findOne(document.getProjectId());
+        project.validateUserPermission(username);
         document.update(request.getTitle(), request.getContent(), request.getDescription(), request.getThumbnailUrl());
         Document savedDocument = documentRepository.save(document);
         documentEventPublisher.publishUpdated(savedDocument);
@@ -51,8 +59,10 @@ public class DocumentService {
     }
 
     @Transactional
-    public void deleteDocument(Long documentId) {
+    public void deleteDocument(Long documentId, String username) {
         Document document = documentRepository.findById(documentId);
+        Project project = projectRepository.findOne(document.getProjectId());
+        project.validateUserPermission(username);
         documentRepository.delete(document);
         documentEventPublisher.publishDeleted(documentId.toString());
     }

--- a/src/main/java/com/sejong/projectservice/application/internal/UserExternalService.java
+++ b/src/main/java/com/sejong/projectservice/application/internal/UserExternalService.java
@@ -6,7 +6,10 @@ import com.sejong.projectservice.application.common.error.code.ErrorCode;
 import com.sejong.projectservice.application.common.error.exception.ApiException;
 import com.sejong.projectservice.infrastructure.client.UserClient;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+
 import java.util.List;
+import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -32,20 +35,38 @@ public class UserExternalService {
         if (t instanceof ApiException) {
             throw (ApiException) t;
         }
-        
+
         throw new ApiException(ErrorCode.EXTERNAL_SERVER_ERROR, "잠시 서비스 이용이 불가합니다.");
     }
 
     @CircuitBreaker(name = "user-circuit-breaker", fallbackMethod = "validateExistenceFallback")
-    public void validateExistence(String username,List<String> collaboratorUsernames) {
-        ResponseEntity<Boolean> response = userClient.exists(username,collaboratorUsernames);
+    public void validateExistence(String username, List<String> collaboratorUsernames) {
+        ResponseEntity<Boolean> response = userClient.exists(username, collaboratorUsernames);
         if (response.getBody() != Boolean.TRUE) {
             throw new ApiException(INVALID_USERS_NICKNAME, "닉네임 목록을 다시 확인하세요.");
         }
     }
 
     private void validateExistenceFallback(String username, List<String> collaboratorUsernames, Throwable t) {
-        log.info("fallback method is called. userName: {}, collaboratorUserCount : {}", username,collaboratorUsernames.size());
+        log.info("fallback method is called. userName: {}, collaboratorUserCount : {}", username, collaboratorUsernames.size());
+        if (t instanceof ApiException) {
+            throw (ApiException) t;
+        }
+
+        throw new ApiException(ErrorCode.EXTERNAL_SERVER_ERROR, "잠시 서비스 이용이 불가합니다.");
+    }
+
+    @CircuitBreaker(name = "user-circuit-breaker", fallbackMethod = "getAllUsernamesFallback")
+    public Map<String, String> getAllUsernames(List<String> usernames) {
+        ResponseEntity<Map<String, String>> response = userClient.getAllUsernames(usernames);
+        if (response.getBody() == null) {
+            throw new ApiException(ErrorCode.EXTERNAL_SERVER_ERROR);
+        }
+        return response.getBody();
+    }
+
+    private void getAllUsernamesFallback(List<String> usernames, Throwable t) {
+        log.info("getAllUsernamesFallback 작동");
         if (t instanceof ApiException) {
             throw (ApiException) t;
         }

--- a/src/main/java/com/sejong/projectservice/application/internal/UserExternalService.java
+++ b/src/main/java/com/sejong/projectservice/application/internal/UserExternalService.java
@@ -35,4 +35,21 @@ public class UserExternalService {
         
         throw new ApiException(ErrorCode.EXTERNAL_SERVER_ERROR, "잠시 서비스 이용이 불가합니다.");
     }
+
+    @CircuitBreaker(name = "user-circuit-breaker", fallbackMethod = "validateExistenceFallback")
+    public void validateExistence(String username,List<String> collaboratorUsernames) {
+        ResponseEntity<Boolean> response = userClient.exists(username,collaboratorUsernames);
+        if (response.getBody() != Boolean.TRUE) {
+            throw new ApiException(INVALID_USERS_NICKNAME, "닉네임 목록을 다시 확인하세요.");
+        }
+    }
+
+    private void validateExistenceFallback(String username, List<String> collaboratorUsernames, Throwable t) {
+        log.info("fallback method is called. userName: {}, collaboratorUserCount : {}", username,collaboratorUsernames.size());
+        if (t instanceof ApiException) {
+            throw (ApiException) t;
+        }
+
+        throw new ApiException(ErrorCode.EXTERNAL_SERVER_ERROR, "잠시 서비스 이용이 불가합니다.");
+    }
 }

--- a/src/main/java/com/sejong/projectservice/application/project/assembler/Assembler.java
+++ b/src/main/java/com/sejong/projectservice/application/project/assembler/Assembler.java
@@ -46,7 +46,7 @@ public class Assembler {
 
         return Project.builder()
                 .title(request.getTitle())
-                .userNickname(userNickname)
+                .username(userNickname)
                 .description(request.getDescription())
                 .categories(categories)
                 .projectStatus(request.getProjectStatus())

--- a/src/main/java/com/sejong/projectservice/application/project/controller/ProjectController.java
+++ b/src/main/java/com/sejong/projectservice/application/project/controller/ProjectController.java
@@ -56,10 +56,11 @@ public class ProjectController {
     @PutMapping("/{projectId}")
     @Operation(summary = "프로젝트 기본 정보 수정")
     public ResponseEntity<ProjectUpdateResponse> updateProject(
+            @RequestHeader("X-User-Id") String username,
             @PathVariable(name = "projectId") Long projectId,
             @RequestBody ProjectUpdateRequest projectUpdateRequest
     ) {
-        ProjectUpdateResponse response = projectService.update(projectId, projectUpdateRequest);
+        ProjectUpdateResponse response = projectService.update(projectId, projectUpdateRequest, username);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(response);
     }
@@ -99,10 +100,10 @@ public class ProjectController {
     @DeleteMapping("/{projectId}")
     @Operation(summary = "프로젝트 삭제")
     public ResponseEntity<ProjectDeleteResponse> deleteProject(
-            @RequestHeader("X-User-Nickname") String userNickname,
+            @RequestHeader("X-User-Id") String username,
             @PathVariable Long projectId
     ) {
-        ProjectDeleteResponse response = projectService.removeProject(userNickname, projectId);
+        ProjectDeleteResponse response = projectService.removeProject(username, projectId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(response);
     }

--- a/src/main/java/com/sejong/projectservice/application/project/controller/ProjectController.java
+++ b/src/main/java/com/sejong/projectservice/application/project/controller/ProjectController.java
@@ -30,9 +30,9 @@ public class ProjectController {
     @PostMapping()
     @Operation(summary = "프로젝트 생성")
     public ResponseEntity<ProjectAddResponse> createProject(
-            @RequestHeader("X-User-Nickname") String userNickname,
+            @RequestHeader("X-User-Id") String username,
             @RequestBody ProjectFormRequest projectFormRequest) {
-        ProjectAddResponse response = projectService.createProject(projectFormRequest, userNickname);
+        ProjectAddResponse response = projectService.createProject(projectFormRequest, username);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(response);

--- a/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectPageResponse.java
+++ b/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectPageResponse.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @AllArgsConstructor
@@ -20,10 +21,12 @@ public class ProjectPageResponse {
     Long totalElements;
     int page;
 
-    public static ProjectPageResponse from(Page<Project> projectPage) {
+    public static ProjectPageResponse from(Page<Project> projectPage, Map<String , String> usernames) {
 
         List<ProjectSimpleInfo> projectSimpleInfos = projectPage.stream()
-                .map(ProjectSimpleInfo::from)
+                .map(project->{
+                    return ProjectSimpleInfo.from(project, usernames);
+                })
                 .toList();
 
         return ProjectPageResponse.builder()

--- a/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectSimpleInfo.java
+++ b/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectSimpleInfo.java
@@ -1,5 +1,6 @@
 package com.sejong.projectservice.application.project.dto.response;
 
+import com.sejong.projectservice.application.collaborator.dto.response.CollaboratorResponse;
 import com.sejong.projectservice.core.category.Category;
 import com.sejong.projectservice.core.collaborator.domain.Collaborator;
 import com.sejong.projectservice.core.enums.ProjectStatus;
@@ -9,6 +10,8 @@ import com.sejong.projectservice.core.techstack.TechStack;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -23,6 +26,8 @@ public class ProjectSimpleInfo {
     private String title;
     private String description;
 
+    private String username;
+    private String ownerNickname;
     private ProjectStatus projectStatus;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -31,16 +36,21 @@ public class ProjectSimpleInfo {
     private List<SubGoal> subGoals = new ArrayList<>();
     private List<Category> categories = new ArrayList<>();
     private List<TechStack> techStacks = new ArrayList<>();
-    private List<Collaborator> collaborators = new ArrayList<>();
+    private List<CollaboratorResponse> collaborators = new ArrayList<>();
     private Integer collaboratorSize;
 
-    public static ProjectSimpleInfo from(Project project) {
+    public static ProjectSimpleInfo from(Project project, Map<String, String> usernames) {
 
-        List<Collaborator> collaboratorList = project.getCollaborators();
+        List<CollaboratorResponse> collaboratorList = project.getCollaborators().stream()
+                .map(collaborator->{
+                    return CollaboratorResponse.of(collaborator.getId(),collaborator.getCollaboratorName(),usernames.get(collaborator.getCollaboratorName()));
+                }).toList();
 
         return ProjectSimpleInfo.builder()
                 .id(project.getId())
                 .title(project.getTitle())
+                .username(project.getUsername())
+                .ownerNickname(usernames.get(project.getUsername()))
                 .description(project.getDescription())
                 .projectStatus(project.getProjectStatus())
                 .createdAt(project.getCreatedAt())

--- a/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectSpecifyInfo.java
+++ b/src/main/java/com/sejong/projectservice/application/project/dto/response/ProjectSpecifyInfo.java
@@ -1,5 +1,6 @@
 package com.sejong.projectservice.application.project.dto.response;
 
+import com.sejong.projectservice.application.collaborator.dto.response.CollaboratorResponse;
 import com.sejong.projectservice.core.category.Category;
 import com.sejong.projectservice.core.collaborator.domain.Collaborator;
 import com.sejong.projectservice.core.document.domain.Document;
@@ -10,6 +11,8 @@ import com.sejong.projectservice.core.techstack.TechStack;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -24,6 +27,8 @@ public class ProjectSpecifyInfo {
     private Long id;
     private String title;
     private String description;
+    private String username;
+    private String ownerNickname;
     private ProjectStatus projectStatus;
 
     private LocalDateTime createdAt;
@@ -35,13 +40,21 @@ public class ProjectSpecifyInfo {
     private List<SubGoal> subGoals = new ArrayList<>();
     private List<Category> categories = new ArrayList<>();
     private List<TechStack> techStacks = new ArrayList<>();
-    private List<Collaborator> collaborators = new ArrayList<>();
+    private List<CollaboratorResponse> collaborators = new ArrayList<>();
     private List<Document> documents = new ArrayList<>();
 
-    public static ProjectSpecifyInfo from(Project project) {
+    public static ProjectSpecifyInfo from(Project project, Map<String,String> usernames) {
+
+        List<CollaboratorResponse> collaboratorResponseList = project.getCollaborators().stream()
+                .map(collaborator -> {
+                    return CollaboratorResponse.of(collaborator.getId(), collaborator.getCollaboratorName(), usernames.get(collaborator.getCollaboratorName()));
+                }).toList();
+
         return ProjectSpecifyInfo.builder()
                 .id(project.getId())
                 .title(project.getTitle())
+                .username(project.getUsername())
+                .ownerNickname(usernames.get(project.getUsername()))
                 .description(project.getDescription())
                 .projectStatus(project.getProjectStatus())
                 .createdAt(project.getCreatedAt())
@@ -50,7 +63,7 @@ public class ProjectSpecifyInfo {
                 .categories(project.getCategories())
                 .subGoals(project.getSubGoals())
                 .techStacks(project.getTechStacks())
-                .collaborators(project.getCollaborators())
+                .collaborators(collaboratorResponseList)
                 .documents(project.getDocuments())
                 .build();
     }

--- a/src/main/java/com/sejong/projectservice/application/project/service/ProjectService.java
+++ b/src/main/java/com/sejong/projectservice/application/project/service/ProjectService.java
@@ -15,6 +15,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 public class ProjectService {
@@ -32,15 +36,11 @@ public class ProjectService {
         return ProjectAddResponse.from(savedProject.getTitle(), "저장 완료");
     }
 
-    public ProjectPageResponse getAllProjects(Pageable pageable) {
-
-        Page<Project> projectPage = projectRepository.findAll(pageable);
-        return ProjectPageResponse.from(projectPage);
-    }
-
     @Transactional
-    public ProjectUpdateResponse update(Long projectId, ProjectUpdateRequest projectUpdateRequest) {
+    public ProjectUpdateResponse update(Long projectId, ProjectUpdateRequest projectUpdateRequest,String username) {
         Project project = projectRepository.findOne(projectId);
+        project.validateUserPermission(username);
+
         project.update(projectUpdateRequest.getTitle(), projectUpdateRequest.getDescription(),
                 projectUpdateRequest.getProjectStatus(),
                 projectUpdateRequest.getThumbnailUrl());
@@ -49,29 +49,43 @@ public class ProjectService {
         return ProjectUpdateResponse.from(savedProject.getTitle(), "수정 완료");
     }
 
-    public ProjectPageResponse search(String keyword, ProjectStatus status, Pageable pageable) {
-        Page<Project> projectPage = projectRepository.searchWithFilters(keyword, status, pageable);
-        return ProjectPageResponse.from(projectPage);
+    @Transactional
+    public ProjectDeleteResponse removeProject(String username, Long projectId) {
+        Project project = projectRepository.findOne(projectId);
+        project.validateOwner(username);
+        projectRepository.deleteById(projectId);
+        projectEventPublisher.publishDeleted(projectId.toString());
+        return ProjectDeleteResponse.of(project.getTitle(), "삭제 완료");
     }
 
+    @Transactional(readOnly = true)
+    public ProjectPageResponse getAllProjects(Pageable pageable) {
+
+        Page<Project> projectPage = projectRepository.findAll(pageable);
+        List<String> usernames = ProjectUsernamesExtractor.extract(projectPage.getContent());
+
+        Map<String,String> usernamesMap = userExternalService.getAllUsernames(usernames);
+        return ProjectPageResponse.from(projectPage,usernamesMap);
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectPageResponse search(String keyword, ProjectStatus status, Pageable pageable) {
+        Page<Project> projectPage = projectRepository.searchWithFilters(keyword, status, pageable);
+        List<String> usernames = ProjectUsernamesExtractor.extract(projectPage.getContent());
+        Map<String,String> usernamesMap = userExternalService.getAllUsernames(usernames);
+        return ProjectPageResponse.from(projectPage,usernamesMap);
+    }
+
+    @Transactional(readOnly = true)
     public ProjectSpecifyInfo findOne(Long projectId) {
         Project project = projectRepository.findOne(projectId);
-        return ProjectSpecifyInfo.from(project);
+        List<String> usernames = ProjectUsernamesExtractor.extract(project);
+        Map<String,String> usernamesMap = userExternalService.getAllUsernames(usernames);
+        return ProjectSpecifyInfo.from(project,usernamesMap);
     }
 
     @Transactional(readOnly = true)
     public boolean exists(Long postId) {
         return projectRepository.existsById(postId);
     }
-
-    @Transactional
-    public ProjectDeleteResponse removeProject(String userNickname, Long projectId) {
-        Project project = projectRepository.findOne(projectId);
-        project.validateOwner(userNickname);
-        projectRepository.deleteById(projectId);
-        projectEventPublisher.publishDeleted(projectId.toString());
-        return ProjectDeleteResponse.of(project.getTitle(), "삭제 완료");
-    }
-
-
 }

--- a/src/main/java/com/sejong/projectservice/application/project/service/ProjectService.java
+++ b/src/main/java/com/sejong/projectservice/application/project/service/ProjectService.java
@@ -24,9 +24,9 @@ public class ProjectService {
     private final ProjectEventPublisher projectEventPublisher;
 
     @Transactional
-    public ProjectAddResponse createProject(ProjectFormRequest projectFormRequest, String userNickname) {
-//        userExternalService.validateExistence(projectFormRequest.getCollaborators());
-        Project project = Assembler.toProject(projectFormRequest, userNickname);
+    public ProjectAddResponse createProject(ProjectFormRequest projectFormRequest, String username) {
+        userExternalService.validateExistence(username, projectFormRequest.getCollaborators());
+        Project project = Assembler.toProject(projectFormRequest, username);
         Project savedProject = projectRepository.save(project);
         projectEventPublisher.publishCreated(savedProject);
         return ProjectAddResponse.from(savedProject.getTitle(), "저장 완료");
@@ -70,7 +70,7 @@ public class ProjectService {
         project.validateOwner(userNickname);
         projectRepository.deleteById(projectId);
         projectEventPublisher.publishDeleted(projectId.toString());
-        return ProjectDeleteResponse.of(project.getTitle(),"삭제 완료");
+        return ProjectDeleteResponse.of(project.getTitle(), "삭제 완료");
     }
 
 

--- a/src/main/java/com/sejong/projectservice/application/project/service/ProjectUsernamesExtractor.java
+++ b/src/main/java/com/sejong/projectservice/application/project/service/ProjectUsernamesExtractor.java
@@ -1,0 +1,4 @@
+package com.sejong.projectservice.application.project.service;
+
+public class ProjectUsernamesExtractor {
+}

--- a/src/main/java/com/sejong/projectservice/application/project/service/ProjectUsernamesExtractor.java
+++ b/src/main/java/com/sejong/projectservice/application/project/service/ProjectUsernamesExtractor.java
@@ -1,4 +1,29 @@
 package com.sejong.projectservice.application.project.service;
 
+import com.sejong.projectservice.core.collaborator.domain.Collaborator;
+import com.sejong.projectservice.core.project.domain.Project;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
 public class ProjectUsernamesExtractor {
+
+    public static List<String> extract(List<Project> projects) {
+        return projects.stream()
+                .flatMap(project -> Stream.concat(
+                        Stream.of(project.getUsername()),
+                        project.getCollaborators().stream()
+                                .map(Collaborator::getCollaboratorName)
+                ))
+                .toList();
+    }
+
+    public static List<String> extract(Project project) {
+        List<String> usernames = new ArrayList<>();
+        usernames.add(project.getUsername());
+        project.getCollaborators()
+                .forEach(it->usernames.add(it.getCollaboratorName()));
+        return usernames;
+    }
 }

--- a/src/main/java/com/sejong/projectservice/application/subgoal/controller/SubGoalController.java
+++ b/src/main/java/com/sejong/projectservice/application/subgoal/controller/SubGoalController.java
@@ -22,33 +22,33 @@ public class SubGoalController {
     @PutMapping("/check/{projectId}")
     @Operation(summary ="서브 목표 달성 완료 기능")
     public ResponseEntity<SubGoalCheckResponse> checkSubGoal(
-            @RequestHeader("x-user-name") String userName,
+            @RequestHeader("X-User-Id") String username,
             @PathVariable(name="projectId") Long projectId,
             @RequestParam(name = "subGoalId") Long subGoalId
     ){
-        SubGoalCheckResponse response = subGoalService.updateCheck(userName,projectId, subGoalId);
+        SubGoalCheckResponse response = subGoalService.updateCheck(username,projectId, subGoalId);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/{projectId}")
     @Operation(summary ="서브 목표 추가")
     public ResponseEntity<SubGoalResponse> addSubGoal(
-            @RequestHeader("x-user-name") String userName,
+            @RequestHeader("X-User-Id") String username,
             @PathVariable(name="projectId") Long projectId,
             @RequestBody SubGoalRequest subGoalRequest
     ){
-        SubGoalResponse response = subGoalService.create(userName,projectId, subGoalRequest.getContent());
+        SubGoalResponse response = subGoalService.create(username,projectId, subGoalRequest.getContent());
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{projectId}/{subGoalId}")
     @Operation(summary = "서브 목표 삭제")
     public ResponseEntity<SubGoalDeleteResponse> deleteSubGoal(
-            @RequestHeader("x-user-name") String userName,
+            @RequestHeader("X-User-Id") String username,
             @PathVariable(name="projectId") Long projectId,
             @PathVariable(name="subGoalId") Long subGoalId
     ){
-        SubGoalDeleteResponse response = subGoalService.remove(userName, projectId, subGoalId);
+        SubGoalDeleteResponse response = subGoalService.remove(username, projectId, subGoalId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/sejong/projectservice/application/subgoal/service/SubGoalService.java
+++ b/src/main/java/com/sejong/projectservice/application/subgoal/service/SubGoalService.java
@@ -21,9 +21,9 @@ public class SubGoalService {
     private final ProjectRepository projectRepository;
 
     @Transactional
-    public SubGoalCheckResponse updateCheck(String userName, Long projectId , Long subGoalId) {
+    public SubGoalCheckResponse updateCheck(String username, Long projectId , Long subGoalId) {
         Project project = projectRepository.findOne(projectId);
-//        project.ensureCollaboratorExists(userName);
+        project.validateUserPermission(username);
         SubGoal subGoal = subGoalRepository.findOne(subGoalId);
         subGoal.check();
         SubGoal updatedSubGoal = subGoalRepository.update(subGoal);
@@ -31,18 +31,18 @@ public class SubGoalService {
     }
 
     @Transactional
-    public SubGoalResponse create(String userName, Long projectId, String content) {
+    public SubGoalResponse create(String username, Long projectId, String content) {
         Project project = projectRepository.findOne(projectId);
-//        project.ensureCollaboratorExists(userName);
+        project.validateUserPermission(username);
         SubGoal subGoal = SubGoal.from(content, false, LocalDateTime.now(), LocalDateTime.now());
         SubGoal savedSubGoal = subGoalRepository.save(projectId, subGoal);
         return SubGoalResponse.from(savedSubGoal);
     }
 
     @Transactional
-    public SubGoalDeleteResponse remove(String userName, Long projectId, Long subGoalId) {
+    public SubGoalDeleteResponse remove(String username, Long projectId, Long subGoalId) {
         Project project = projectRepository.findOne(projectId);
-//        project.ensureCollaboratorExists(userName);
+        project.validateUserPermission(username);
         subGoalRepository.delete(subGoalId);
         return SubGoalDeleteResponse.of(subGoalId);
     }

--- a/src/main/java/com/sejong/projectservice/application/techstack/controller/TechStackController.java
+++ b/src/main/java/com/sejong/projectservice/application/techstack/controller/TechStackController.java
@@ -7,14 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,10 +19,11 @@ public class TechStackController {
     @PostMapping()
     @Operation(summary = "테크스택 생성")
     public ResponseEntity<TechStackRes> createTechStack(
+            @RequestHeader("X-User-Role") String userRole,
             @RequestBody TechStackCreateReq techstackCreateReq
     ) {
         // TODO: 권한 검증
-        TechStackRes response = techstackService.createTechStack(techstackCreateReq);
+        TechStackRes response = techstackService.createTechStack(techstackCreateReq,userRole);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(response);
@@ -47,21 +41,23 @@ public class TechStackController {
     @PutMapping("/{techStackId}")
     @Operation(summary = " 테크스택 수정")
     public ResponseEntity<TechStackRes> updateTechStack(
+            @RequestHeader("X-User-Role") String userRole,
             @PathVariable(name = "techStackId") Long techStackId,
             @RequestBody TechStackCreateReq techstackCreateReq
     ) {
         // TODO: 권한 검증
-        TechStackRes response = techstackService.updateTechStack(techStackId, techstackCreateReq);
+        TechStackRes response = techstackService.updateTechStack(techStackId, techstackCreateReq,userRole);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{techStackId}")
     @Operation(summary = "테크스택 삭제")
     public ResponseEntity<Void> deleteTechStack(
+            @RequestHeader("X-User-Role") String userRole,
             @PathVariable(name = "techStackId") Long techStackId
     ) {
         // TODO: 권한 검증
-        techstackService.deleteTechStack(techStackId);
+        techstackService.deleteTechStack(techStackId,userRole);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sejong/projectservice/application/techstack/service/TechStackService.java
+++ b/src/main/java/com/sejong/projectservice/application/techstack/service/TechStackService.java
@@ -1,12 +1,14 @@
 package com.sejong.projectservice.application.techstack.service;
 
+import com.sejong.projectservice.application.common.error.code.ErrorCode;
+import com.sejong.projectservice.application.common.error.exception.ApiException;
 import com.sejong.projectservice.application.techstack.dto.TechStackCreateReq;
 import com.sejong.projectservice.application.techstack.dto.TechStackRes;
 import com.sejong.projectservice.core.techstack.TechStack;
 import com.sejong.projectservice.core.techstack.TechstackRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,19 +17,28 @@ public class TechStackService {
     private final TechstackRepository techstackRepository;
 
     @Transactional
-    public TechStackRes createTechStack(TechStackCreateReq techstackCreateReq) {
+    public TechStackRes createTechStack(TechStackCreateReq techstackCreateReq, String userRole) {
+        validateAdminRole(userRole);
         TechStack techStack = techstackCreateReq.toDomain();
         TechStack savedTechstack = techstackRepository.save(techStack);
         return TechStackRes.from(savedTechstack);
     }
 
+    private static void validateAdminRole(String userRole) {
+        if(!userRole.equals("ADMIN")) {
+            throw new ApiException(ErrorCode.BAD_REQUEST,"어드민 전용 권한입니다.");
+        }
+    }
+
+    @Transactional(readOnly = true)
     public TechStackRes getTechStack(Long techStackId) {
         TechStack techStack = techstackRepository.findById(techStackId);
         return TechStackRes.from(techStack);
     }
 
     @Transactional
-    public TechStackRes updateTechStack(Long techStackId, TechStackCreateReq request) {
+    public TechStackRes updateTechStack(Long techStackId, TechStackCreateReq request, String userRole) {
+        validateAdminRole(userRole);
         TechStack techStack = techstackRepository.findById(techStackId);
         techStack.update(request.getName());
         TechStack savedTechStack = techstackRepository.save(techStack);
@@ -35,7 +46,8 @@ public class TechStackService {
     }
 
     @Transactional
-    public void deleteTechStack(Long techStackId) {
+    public void deleteTechStack(Long techStackId, String userRole) {
+        validateAdminRole(userRole);
         techstackRepository.deleteById(techStackId);
     }
 }

--- a/src/main/java/com/sejong/projectservice/application/techstack/service/TechStackService.java
+++ b/src/main/java/com/sejong/projectservice/application/techstack/service/TechStackService.java
@@ -24,9 +24,9 @@ public class TechStackService {
         return TechStackRes.from(savedTechstack);
     }
 
-    private static void validateAdminRole(String userRole) {
-        if(!userRole.equals("ADMIN")) {
-            throw new ApiException(ErrorCode.BAD_REQUEST,"어드민 전용 권한입니다.");
+    private void validateAdminRole(String userRole) {
+        if (!userRole.equals("ADMIN")) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "어드민 전용 권한입니다.");
         }
     }
 

--- a/src/main/java/com/sejong/projectservice/core/project/domain/Project.java
+++ b/src/main/java/com/sejong/projectservice/core/project/domain/Project.java
@@ -26,7 +26,7 @@ public class Project {
     private LocalDateTime createdAt;
 
     private Long id;
-    private String userNickname;
+    private String username;
     private List<Collaborator> collaborators = new ArrayList<>();
 
     private String title;
@@ -52,12 +52,20 @@ public class Project {
         documents.add(doc);
     }
 
-    public void validateOwner(String userNickname) {
-        if(!this.userNickname.equals(userNickname)){
-            throw new ApiException(ErrorCode.BAD_REQUEST,"해당 유저는 프로젝트 Owner가 아닙니다.");
+    public void validateUserPermission(String username){
+        if(this.username.equals(username))return;
+
+        boolean exists = ensureCollaboratorExists(username);
+        if(exists==false){
+            throw new ApiException(ErrorCode.BAD_REQUEST,"해당 유저는 프로젝트 수정 권한이 없습니다.");
         }
     }
 
+    public void validateOwner(String username) {
+        if(!this.username.equals(username)){
+            throw new ApiException(ErrorCode.BAD_REQUEST,"해당 유저는 프로젝트 Owner가 아닙니다.");
+        }
+    }
 
     public void updateCollaborator(List<String> collaboratorNames) {
         List<Collaborator> collaboratorList = collaboratorNames.stream()
@@ -68,16 +76,12 @@ public class Project {
         this.collaborators.clear();
         this.collaborators.addAll(collaboratorList);
     }
-    public void ensureCollaboratorExists(String userName){
+    public boolean ensureCollaboratorExists(String userName){
         boolean exists = collaborators.stream()
                 .anyMatch(collaborator -> collaborator.getCollaboratorName().equals(userName));
 
-        if(exists==false){
-            throw new ApiException(ErrorCode.BAD_REQUEST,"해당 유저는 프로젝트내에 collaborator가 아닙니다.");
-        }
-
+        return exists;
     }
-
 
     public void checkSubGoal(Long subGoalId) {
         SubGoal selectedSubGaol = subGoals.stream()

--- a/src/main/java/com/sejong/projectservice/core/project/domain/Project.java
+++ b/src/main/java/com/sejong/projectservice/core/project/domain/Project.java
@@ -57,7 +57,7 @@ public class Project {
 
         boolean exists = ensureCollaboratorExists(username);
         if(exists==false){
-            throw new ApiException(ErrorCode.BAD_REQUEST,"해당 유저는 프로젝트 수정 권한이 없습니다.");
+            throw new ApiException(ErrorCode.BAD_REQUEST,"해당 유저는 프로젝트 접근 권한이 없습니다.");
         }
     }
 

--- a/src/main/java/com/sejong/projectservice/infrastructure/client/UserClient.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/client/UserClient.java
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "user-service", path = "/internal")
 public interface UserClient {
-    @GetMapping("/{userId}/exists")
-    ResponseEntity<Boolean> exists(@PathVariable("userId") String userId);
+    @GetMapping("/{username}/exists")
+    ResponseEntity<Boolean> exists(@PathVariable("username") String username);
 
     @GetMapping("/exists")
     ResponseEntity<Boolean> existAll(@RequestBody List<String> nicknames);

--- a/src/main/java/com/sejong/projectservice/infrastructure/client/UserClient.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/client/UserClient.java
@@ -2,11 +2,13 @@ package com.sejong.projectservice.infrastructure.client;
 
 
 import java.util.List;
+
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "user-service", path = "/internal")
 public interface UserClient {
@@ -14,5 +16,9 @@ public interface UserClient {
     ResponseEntity<Boolean> exists(@PathVariable("userId") String userId);
 
     @GetMapping("/exists")
-    ResponseEntity<Boolean> existAll(@RequestBody List<String> userNames);
+    ResponseEntity<Boolean> existAll(@RequestBody List<String> nicknames);
+
+    @GetMapping("/{username}/exists/multiple")
+    ResponseEntity<Boolean> exists(@PathVariable("username") String username,
+                                   @RequestParam("collaboratorUsernames") List<String> collaboratorUsernames);
 }

--- a/src/main/java/com/sejong/projectservice/infrastructure/client/UserClient.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/client/UserClient.java
@@ -1,7 +1,7 @@
 package com.sejong.projectservice.infrastructure.client;
 
-
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
@@ -21,4 +21,7 @@ public interface UserClient {
     @GetMapping("/{username}/exists/multiple")
     ResponseEntity<Boolean> exists(@PathVariable("username") String username,
                                    @RequestParam("collaboratorUsernames") List<String> collaboratorUsernames);
+
+    @GetMapping("/all")
+    ResponseEntity<Map<String, String>> getAllUsernames(@RequestParam("usernames") List<String> usernames);
 }

--- a/src/main/java/com/sejong/projectservice/infrastructure/project/entity/ProjectEntity.java
+++ b/src/main/java/com/sejong/projectservice/infrastructure/project/entity/ProjectEntity.java
@@ -19,7 +19,6 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -42,7 +41,7 @@ public class ProjectEntity {
     private String title;
     private String description;
 
-    private String userNickname;
+    private String username;
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(50)")
@@ -72,7 +71,7 @@ public class ProjectEntity {
         return ProjectEntity.builder()
                 .title(project.getTitle())
                 .description(project.getDescription())
-                .userNickname(project.getUserNickname())
+                .username(project.getUsername())
                 .projectStatus(project.getProjectStatus())
                 .thumbnailUrl(project.getThumbnailUrl())
                 .createdAt(project.getCreatedAt())
@@ -153,7 +152,7 @@ public class ProjectEntity {
         return Project.builder()
                 .id(this.id)
                 .title(this.title)
-                .userNickname(this.userNickname)
+                .username(this.username)
                 .description(this.description)
                 .projectStatus(this.projectStatus)
                 .thumbnailUrl(this.thumbnailUrl)
@@ -166,5 +165,4 @@ public class ProjectEntity {
                 .documents(documentList)
                 .build();
     }
-
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -79,6 +79,22 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
 
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      myFeignClient:
+        registerHealthIndicator: true
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 10s
+
+  timelimiter:
+    instances:
+      myFeignClient:
+        timeoutDuration: 3s
+
 logging:
   level:
     org.elasticsearch.client: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,6 +106,7 @@ resilience4j:
     instances:
       myFeignClient:
         timeoutDuration: 3s
+
 logging:
   level:
     org.elasticsearch.client: TRACE


### PR DESCRIPTION
## #️⃣ 이슈
- close #22

---

## 🔎 작업 내용
- **Feign API 구현**
  - username 및 collaborators 식별용 Feign API 구현  
- **추가 클래스 생성**
  - `ProjectUsernamesExtractor`, `CollaboratorResponse` 신규 추가  
- **리팩터링**
  - username 조회 로직 및 관련 클래스 구조 개선  
- **권한 검증 도입**
  - Member 권한 검증 완료
  - 카테고리 CRUD → 어드민 전용 권한 추가
  - 협력자 관련 API → Feign 기반 권한 체크
  - 하위 목표(SubGoal) →  권한 체크
  - 기술스택(TechStack) → 어드민 전용 권한 체크  
- **기타**
  - 컨벤션 정리  
  - main 브랜치와 merge  

---

## 🤔 고민해볼 부분 & 코드 리뷰 희망사항
