### PR TITLE
Article attachment

### DIFF
--- a/src/main/java/com/sejong/projectservice/domains/csknowledge/controller/CsKnowledgeController.java
+++ b/src/main/java/com/sejong/projectservice/domains/csknowledge/controller/CsKnowledgeController.java
@@ -4,6 +4,9 @@ package com.sejong.projectservice.domains.csknowledge.controller;
 import com.sejong.projectservice.domains.csknowledge.dto.CsKnowledgeReqDto;
 import com.sejong.projectservice.domains.csknowledge.dto.CsKnowledgeResDto;
 import com.sejong.projectservice.domains.csknowledge.service.CsKnowledgeService;
+import com.sejong.projectservice.support.common.file.FileUploadRequest;
+import com.sejong.projectservice.support.common.file.FileUploader;
+import com.sejong.projectservice.support.common.file.PreSignedUrl;
 import com.sejong.projectservice.support.common.util.RoleValidator;
 import com.sejong.projectservice.support.common.pagination.CursorPageReqDto;
 import com.sejong.projectservice.support.common.pagination.OffsetPageReqDto;
@@ -28,6 +31,32 @@ import java.util.Optional;
 public class CsKnowledgeController {
 
     private final CsKnowledgeService csKnowledgeService;
+    private final FileUploader fileUploader;
+
+    private static final String CS_KNOWLEDGE_FILE_TYPE = "cs-knowledge";
+
+    @PostMapping("/files/presigned-url")
+    @Operation(summary = "CS 지식 첨부파일 업로드용 Presigned URL 발급")
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<PreSignedUrl> getAttachmentPresignedUrl(
+            @RequestBody FileUploadRequest request,
+            @Parameter(hidden = true) @RequestHeader(value = "X-User-Role", required = false) String userRole
+    ) {
+        RoleValidator.validateNotGuest(userRole);
+        PreSignedUrl preSignedUrl = fileUploader.generatePreSignedUrl(
+                request.fileName(), request.contentType(), CS_KNOWLEDGE_FILE_TYPE);
+        return ResponseEntity.ok(preSignedUrl);
+    }
+
+    @GetMapping("/{csKnowledgeId}/attachments/download")
+    @Operation(summary = "CS 지식 첨부파일 다운로드용 Presigned URL 발급")
+    public ResponseEntity<String> getAttachmentDownloadUrl(
+            @PathVariable Long csKnowledgeId,
+            @RequestParam String key
+    ) {
+        String downloadUrl = csKnowledgeService.generateAttachmentDownloadUrl(csKnowledgeId, key);
+        return ResponseEntity.ok(downloadUrl);
+    }
 
     @PostMapping
     @Operation(summary = "CS 지식 생성 ")

--- a/src/main/java/com/sejong/projectservice/domains/csknowledge/domain/CsKnowledgeAttachment.java
+++ b/src/main/java/com/sejong/projectservice/domains/csknowledge/domain/CsKnowledgeAttachment.java
@@ -1,0 +1,20 @@
+package com.sejong.projectservice.domains.csknowledge.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CsKnowledgeAttachment {
+
+    @Column(name = "file_key", length = 512)
+    private String fileKey;
+
+    @Column(name = "original_file_name", length = 255)
+    private String originalFileName;
+}

--- a/src/main/java/com/sejong/projectservice/domains/csknowledge/domain/CsKnowledgeEntity.java
+++ b/src/main/java/com/sejong/projectservice/domains/csknowledge/domain/CsKnowledgeEntity.java
@@ -5,12 +5,15 @@ import com.sejong.projectservice.domains.category.domain.CategoryEntity;
 import com.sejong.projectservice.support.common.exception.BaseException;
 import com.sejong.projectservice.support.common.exception.ExceptionType;
 import jakarta.persistence.*;
+import org.hibernate.annotations.BatchSize;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(
@@ -43,6 +46,11 @@ public class CsKnowledgeEntity {
 
     @Column(name = "thumbnail_key")
     private String thumbnailKey;
+
+    @ElementCollection
+    @CollectionTable(name = "cs_knowledge_attachment", joinColumns = @JoinColumn(name = "cs_knowledge_id"))
+    @BatchSize(size = 30)
+    private List<CsKnowledgeAttachment> attachments = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
@@ -87,6 +95,14 @@ public class CsKnowledgeEntity {
 
     public void updateThumbnailKey(String thumbnailKey) {
         this.thumbnailKey = thumbnailKey;
+    }
+
+    public void addAttachment(CsKnowledgeAttachment attachment) {
+        this.attachments.add(attachment);
+    }
+
+    public void removeAttachmentByKey(String fileKey) {
+        this.attachments.removeIf(a -> a.getFileKey().equals(fileKey));
     }
 
     public void updateContent(String newContent) {

--- a/src/main/java/com/sejong/projectservice/domains/csknowledge/dto/CsKnowledgeReqDto.java
+++ b/src/main/java/com/sejong/projectservice/domains/csknowledge/dto/CsKnowledgeReqDto.java
@@ -22,6 +22,18 @@ public record CsKnowledgeReqDto(
         String thumbnailKey,
 
         @Schema(description = "에디터 본문에 삽입된 이미지 key 목록")
-        List<String> contentImageKeys
+        List<String> contentImageKeys,
+
+        @Schema(description = "새로 첨부할 파일 목록 (presigned URL 업로드 후 받은 tempKey + 원본 파일명)")
+        List<AttachmentReq> attachments,
+
+        @Schema(description = "삭제할 첨부 파일 key 목록 (수정 시에만 사용)")
+        List<String> attachmentKeysToDelete
 ) {
+    public record AttachmentReq(
+            @Schema(description = "presigned URL 업로드 후 받은 temp key")
+            String tempKey,
+            @Schema(description = "원본 파일명 (예: report.pdf)")
+            String originalFileName
+    ) {}
 }

--- a/src/main/java/com/sejong/projectservice/domains/csknowledge/dto/CsKnowledgeResDto.java
+++ b/src/main/java/com/sejong/projectservice/domains/csknowledge/dto/CsKnowledgeResDto.java
@@ -1,10 +1,12 @@
 package com.sejong.projectservice.domains.csknowledge.dto;
 
+import com.sejong.projectservice.domains.csknowledge.domain.CsKnowledgeAttachment;
 import com.sejong.projectservice.domains.csknowledge.domain.CsKnowledgeEntity;
 import com.sejong.projectservice.support.common.file.FileUploader;
 import com.sejong.projectservice.support.common.internal.response.UserProfileDto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record CsKnowledgeResDto(
         Long id,
@@ -14,8 +16,15 @@ public record CsKnowledgeResDto(
         UserProfileDto writerProfile,
         String category,
         String thumbnailUrl,
+        List<AttachmentInfo> attachments,
         LocalDateTime createdAt
 ) {
+
+    public record AttachmentInfo(String fileKey, String originalFileName) {
+        public static AttachmentInfo from(CsKnowledgeAttachment attachment) {
+            return new AttachmentInfo(attachment.getFileKey(), attachment.getOriginalFileName());
+        }
+    }
 
     public static CsKnowledgeResDto from(
             CsKnowledgeEntity csKnowledgeEntity,
@@ -26,6 +35,10 @@ public record CsKnowledgeResDto(
                 ? fileUploader.getFileUrl(csKnowledgeEntity.getThumbnailKey())
                 : null;
 
+        List<AttachmentInfo> attachments = csKnowledgeEntity.getAttachments().stream()
+                .map(AttachmentInfo::from)
+                .toList();
+
         return new CsKnowledgeResDto(
                 csKnowledgeEntity.getId(),
                 csKnowledgeEntity.getTitle(),
@@ -34,6 +47,7 @@ public record CsKnowledgeResDto(
                 writerProfile,
                 csKnowledgeEntity.getCategoryEntity().getName(),
                 thumbnailUrl,
+                attachments,
                 csKnowledgeEntity.getCreatedAt()
         );
     }

--- a/src/main/java/com/sejong/projectservice/domains/csknowledge/service/CsKnowledgeService.java
+++ b/src/main/java/com/sejong/projectservice/domains/csknowledge/service/CsKnowledgeService.java
@@ -3,6 +3,7 @@ package com.sejong.projectservice.domains.csknowledge.service;
 
 import com.sejong.projectservice.domains.category.domain.CategoryEntity;
 import com.sejong.projectservice.domains.category.repository.CategoryRepository;
+import com.sejong.projectservice.domains.csknowledge.domain.CsKnowledgeAttachment;
 import com.sejong.projectservice.domains.csknowledge.domain.CsKnowledgeEntity;
 import com.sejong.projectservice.domains.csknowledge.repository.CsKnowledgeRepository;
 import com.sejong.projectservice.domains.csknowledge.dto.CsKnowledgeReqDto;
@@ -87,6 +88,11 @@ public class CsKnowledgeService {
             savedEntity.updateContent(updatedContent);
         }
 
+        // 첨부파일 처리 (temp → 최종 위치)
+        if (csKnowledgeReqDto.attachments() != null && !csKnowledgeReqDto.attachments().isEmpty()) {
+            processAttachments(savedEntity, csKnowledgeReqDto.attachments());
+        }
+
         CsKnowledgeResDto response = resolveUsername(savedEntity);
         OutboxEventRequest outbox = OutboxEventRequest.of(csKnowledgeEntity, fileUploader, Type.CREATED);
         outboxService.enqueue(outbox);
@@ -137,6 +143,23 @@ public class CsKnowledgeService {
             csKnowledgeEntity.updateContent(updatedContent);
         }
 
+        // 첨부파일 삭제
+        if (csKnowledgeReqDto.attachmentKeysToDelete() != null && !csKnowledgeReqDto.attachmentKeysToDelete().isEmpty()) {
+            for (String fileKey : csKnowledgeReqDto.attachmentKeysToDelete()) {
+                try {
+                    fileUploader.delete(fileKey);
+                } catch (Exception e) {
+                    log.warn("첨부파일 삭제 실패, 계속 진행: {}", fileKey, e);
+                }
+                csKnowledgeEntity.removeAttachmentByKey(fileKey);
+            }
+        }
+
+        // 새 첨부파일 추가
+        if (csKnowledgeReqDto.attachments() != null && !csKnowledgeReqDto.attachments().isEmpty()) {
+            processAttachments(csKnowledgeEntity, csKnowledgeReqDto.attachments());
+        }
+
         CsKnowledgeResDto response = resolveUsername(csKnowledgeEntity);
         OutboxEventRequest outbox = OutboxEventRequest.of(csKnowledgeEntity, fileUploader, Type.UPDATED);
         outboxService.enqueue(outbox);
@@ -148,6 +171,16 @@ public class CsKnowledgeService {
         CsKnowledgeEntity csKnowledgeEntity = csKnowledgeRepository.findById(csKnowledgeId)
                 .orElseThrow(() -> new BaseException(ExceptionType.CS_KNOWLEDGE_NOT_FOUND));
         csKnowledgeEntity.validateOwnerPermission(username, userRole);
+
+        // 첨부파일 전체 삭제
+        csKnowledgeEntity.getAttachments().forEach(attachment -> {
+            try {
+                fileUploader.delete(attachment.getFileKey());
+            } catch (Exception e) {
+                log.warn("첨부파일 삭제 실패, 계속 진행: {}", attachment.getFileKey(), e);
+            }
+        });
+
         csKnowledgeRepository.deleteById(csKnowledgeEntity.getId());
         OutboxEventRequest outbox = OutboxEventRequest.remove(csKnowledgeEntity, Type.DELETED);
         outboxService.enqueue(outbox);
@@ -272,6 +305,31 @@ public class CsKnowledgeService {
     @Transactional(readOnly = true)
     public List<Long> getCsKnowledgeIdsByUsername(String username) {
         return csKnowledgeRepository.findCsKnowledgeIdsByUsername(username);
+    }
+
+    public String generateAttachmentDownloadUrl(Long csKnowledgeId, String fileKey) {
+        CsKnowledgeEntity entity = csKnowledgeRepository.findById(csKnowledgeId)
+                .orElseThrow(() -> new BaseException(ExceptionType.CS_KNOWLEDGE_NOT_FOUND));
+
+        CsKnowledgeAttachment attachment = entity.getAttachments().stream()
+                .filter(a -> a.getFileKey().equals(fileKey))
+                .findFirst()
+                .orElseThrow(() -> new BaseException(ExceptionType.FILE_NOT_FOUND));
+
+        return fileUploader.generateDownloadPresignedUrl(attachment.getFileKey(), attachment.getOriginalFileName());
+    }
+
+    private void processAttachments(CsKnowledgeEntity entity, List<CsKnowledgeReqDto.AttachmentReq> attachmentReqs) {
+        String targetDir = String.format("project-service/cs-knowledge/%d/attachments", entity.getId());
+        for (CsKnowledgeReqDto.AttachmentReq req : attachmentReqs) {
+            if (req.tempKey() == null || req.tempKey().isEmpty()) continue;
+            try {
+                String finalKey = fileUploader.moveFile(req.tempKey(), targetDir);
+                entity.addAttachment(new CsKnowledgeAttachment(finalKey, req.originalFileName()));
+            } catch (Exception e) {
+                log.warn("첨부파일 이동 실패, 스킵: {}", req.tempKey(), e);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/sejong/projectservice/support/common/exception/ExceptionType.java
+++ b/src/main/java/com/sejong/projectservice/support/common/exception/ExceptionType.java
@@ -40,6 +40,7 @@ public enum ExceptionType implements ExceptionTypeIfs {
     EXTERNAL_SERVICE_ERROR(503, "외부 서비스 연결 실패"),
     KAFKA_PUBLISH_ERROR(500, "이벤트 발행 실패"),
     JSON_PARSHING_ERROR(500, "Json 파싱 에러"),
+    FILE_NOT_FOUND(404, "첨부파일을 찾을 수 없습니다"),
     FILE_REMOVE_FAIL(500, "파일 삭제 실패"),
     FILE_MOVE_FAIL(500, "파일 이동 실패"),
     FILE_UPLOAD_FAIL(500, "파일 업로드 실패"),

--- a/src/main/java/com/sejong/projectservice/support/common/file/FileUploader.java
+++ b/src/main/java/com/sejong/projectservice/support/common/file/FileUploader.java
@@ -14,4 +14,5 @@ public interface FileUploader {
     void delete(String keyOrUrl);
     String getFileUrl(String keyOrUrl);
     String extractKeyFromUrl(String url);
+    String generateDownloadPresignedUrl(String key, String originalFileName);
 }

--- a/src/main/java/com/sejong/projectservice/support/common/file/S3FileUploader.java
+++ b/src/main/java/com/sejong/projectservice/support/common/file/S3FileUploader.java
@@ -16,6 +16,9 @@ import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
@@ -177,6 +180,32 @@ public class S3FileUploader implements FileUploader {
         } catch (Exception e) {
             log.error("S3 파일 이동 실패: {} -> {}", sourceKey, targetDirectory, e);
             throw new BaseException(ExceptionType.FILE_MOVE_FAIL);
+        }
+    }
+
+    /**
+     * 파일 다운로드용 Presigned GET URL 생성
+     * Content-Disposition: attachment 헤더로 브라우저 강제 다운로드 유도
+     */
+    @Override
+    public String generateDownloadPresignedUrl(String key, String originalFileName) {
+        try {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .responseContentDisposition("attachment; filename=\"" + originalFileName + "\"")
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(10))
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+            return presignedRequest.url().toString();
+        } catch (Exception e) {
+            log.error("다운로드 Presigned URL 생성 실패: {}", key, e);
+            throw new BaseException(ExceptionType.FILE_UPLOAD_FAIL);
         }
     }
 

--- a/src/main/resources/db/migration/V20260324__cs_knowledge_add_attachment.sql
+++ b/src/main/resources/db/migration/V20260324__cs_knowledge_add_attachment.sql
@@ -1,0 +1,8 @@
+CREATE TABLE cs_knowledge_attachment
+(
+    cs_knowledge_id  BIGINT       NOT NULL,
+    file_key         VARCHAR(512) NOT NULL,
+    original_file_name VARCHAR(255),
+    CONSTRAINT fk_cs_knowledge_attachment FOREIGN KEY (cs_knowledge_id) REFERENCES cs_knowledge (id) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;


### PR DESCRIPTION
## #️⃣이슈

  - close #이슈번호

  ## 🔎 작업 내용

  CS지식 게시글에 이미지 외 파일(PDF, ZIP 등 모든 형식)을 첨부할 수 있는 기능을 추가했습니다.

  **도메인**
  - `CsKnowledgeAttachment` @Embeddable 추가 (fileKey + originalFileName)
  - `CsKnowledgeEntity`에 `@ElementCollection` 기반 첨부파일 목록 관리

  **API**
  - `POST /cs-knowledge/files/presigned-url` — 첨부파일 업로드용 presigned PUT URL 발급
  - `GET /cs-knowledge/{id}/attachments/download?key=...` — 첨부파일 다운로드용 presigned GET URL 발급
  - create/update 요청에 `attachments`(신규), `attachmentKeysToDelete`(삭제) 필드 추가
  - delete 시 S3 첨부파일 전체 삭제

  **파일 저장 경로**
  - `project-service/cs-knowledge/{id}/attachments/`

  **DB**
  - `cs_knowledge_attachment` 테이블 추가 (Flyway V20260324)

  ## 🤔 고민해볼 부분 & 코드 리뷰 희망사항

  - 다운로드 presigned URL 유효 시간을 현재 10분으로 설정했는데, 적절한지 검토 부탁드립니다.
  - 첨부파일 개수/용량 제한 로직이 현재 없습니다. 서비스 레이어 또는 게이트웨이에서 제한이 필요한지 논의해주세요.
  - `attachmentKeysToDelete`에 해당 게시글 소유가 아닌 key가 들어올 경우의 보안 처리 검토가 필요합니다.

  ## 🧲 참고 자료 및 공유 사항

  - 다운로드 presigned URL에 `Content-Disposition: attachment; filename="파일명"` 헤더를 포함하여 PDF 등 브라우저 인라인 표시 없이 강제 다운로드됩니다.
  - 기존 썸네일/에디터 이미지와 동일한 temp → 최종 경로 이동 패턴을 따릅니다.
